### PR TITLE
Move error log level to debug in case of exception in processMessage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -226,7 +226,7 @@ module.exports = function createService(url, socketOptions) {
             await handler.call(this, payload);
             await this.acceptMessage(message);
           } catch (error) {
-            this.logger.error(error);
+            this.logger.debug(error);
             // Error handler may change a rejection strategy
             const result = typeof errorStrategy === 'function'
               ? await errorStrategy.call(this, error, payload) : errorStrategy;


### PR DESCRIPTION
in case of manageable exception throwing it spams to log with error level, this patch moves it to debug and makes logs cleaner.